### PR TITLE
createjs display offset

### DIFF
--- a/src/factory/createjsFactory.js
+++ b/src/factory/createjsFactory.js
@@ -125,8 +125,8 @@
                 var subTextureFrame = textureAtlas.getFrame(fullName);
                 if(subTextureFrame != null)
                 {
-                    pivotX = subTextureFrame.width/2;
-                    pivotY = subTextureFrame.height/2;
+                    pivotX = (subTextureFrame.width/2)+subTextureFrame.x;
+                    pivotY = (subTextureFrame.height/2)+subTextureFrame.y;
                 }
                 else
                 {


### PR DESCRIPTION
offset fix for TextureAtlases created with whitespace removal enabled
